### PR TITLE
Update MacGIContext

### DIFF
--- a/src/Raylib-CSharp.Samples/CMake.props
+++ b/src/Raylib-CSharp.Samples/CMake.props
@@ -12,7 +12,7 @@
     </PropertyGroup>
 
     <PropertyGroup Condition="$([MSBuild]::IsOSPlatform('OSX'))">
-        <RlName>libraylib.so</RlName>
+        <RlName>libraylib.dylib</RlName>
     </PropertyGroup>
 
     <!-- Todo: When "dev-5.1" release move back to "Tags" instead of "commits": "https://github.com/raysan5/raylib/archive/refs/tags/$(RlVersion).zip" -->

--- a/src/Raylib-CSharp.Test/CMake.props
+++ b/src/Raylib-CSharp.Test/CMake.props
@@ -12,7 +12,7 @@
     </PropertyGroup>
 
     <PropertyGroup Condition="$([MSBuild]::IsOSPlatform('OSX'))">
-        <RlName>libraylib.so</RlName>
+        <RlName>libraylib.dylib</RlName>
     </PropertyGroup>
     
     <!-- Todo: When "dev-5.1" release move back to "Tags" instead of "commits": "https://github.com/raysan5/raylib/archive/refs/tags/$(RlVersion).zip" -->

--- a/src/Raylib-CSharp.Test/Program.cs
+++ b/src/Raylib-CSharp.Test/Program.cs
@@ -8,6 +8,7 @@ using Raylib_CSharp.Images;
 using Raylib_CSharp.IO;
 using Raylib_CSharp.Logging;
 using Raylib_CSharp.Rendering;
+using Raylib_CSharp.Rendering.Gl.Contexts;
 using Raylib_CSharp.Test;
 using Raylib_CSharp.Textures;
 using Raylib_CSharp.Unsafe.Spans.Data;
@@ -115,6 +116,8 @@ GLLoader.LoadBindings(context);
 
 //Span<Matrix4x4> matrix = new(new Matrix4x4[1]);
 //matrix[1] = new Matrix4x4();
+
+context.GetProcAddress("glClearColor");
 
 while (!Window.ShouldClose()) {
     camera3D.Update(CameraMode.Orbital);

--- a/src/Raylib-CSharp/Rendering/Gl/Contexts/MacGlContext.cs
+++ b/src/Raylib-CSharp/Rendering/Gl/Contexts/MacGlContext.cs
@@ -12,12 +12,12 @@ public partial class MacGlContext : IGlContext {
     /// </summary>
     /// <param name="procName">The name of the extension function.</param>
     /// <returns> A pointer to the extension function if found; otherwise, <see cref="nint.Zero"/>.</returns>
-    [LibraryImport(OpenGL, EntryPoint = "NSGetProcAddress", StringMarshalling = StringMarshalling.Utf8)]
+    [LibraryImport(OpenGL, EntryPoint = "NSLookupAndBindSymbol", StringMarshalling = StringMarshalling.Utf8)]
     [UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
-    private static partial nint NsGetProcAddress(string procName);
+    private static partial nint NSLookupAndBindSymbol(string procName);
 
     public nint GetProcAddress(string procName) {
-        nint address = NsGetProcAddress(procName);
+        nint address = NSLookupAndBindSymbol("_" + procName);
 
         if (address == nint.Zero) {
             throw new Exception("Failed to retrieve the Procedure Address.");


### PR DESCRIPTION
I used NSLookupAndBindSymbol based on the Documentation from Apple:
https://developer.apple.com/library/archive/documentation/GraphicsImaging/Conceptual/OpenGL-MacProgGuide/opengl_entrypts/opengl_entrypts.html#//apple_ref/doc/uid/TP40001987-CH402-SW6

The address was gotten:
<img width="934" alt="Screenshot 2024-07-08 at 4 01 40 PM" src="https://github.com/MrScautHD/Raylib-CSharp/assets/6806789/0f9b3351-9422-4bf9-9d82-b0bb74d9f7f2">

I also changed the file that it looks for when building based on how Brew installs raylib:
<img width="848" alt="Screenshot 2024-07-08 at 4 05 53 PM" src="https://github.com/MrScautHD/Raylib-CSharp/assets/6806789/4587e700-9cf5-48fa-a6a1-d99c34c95a50">

Running: 
<img width="1710" alt="Screenshot 2024-07-08 at 4 00 08 PM" src="https://github.com/MrScautHD/Raylib-CSharp/assets/6806789/f3a5764b-fc3b-4ebf-80b2-a734e1a9a6fb">
