### PR TITLE
Add DrawTexturePoly

### DIFF
--- a/src/Raylib-CSharp/Apis/RaylibApi.cs
+++ b/src/Raylib-CSharp/Apis/RaylibApi.cs
@@ -1737,6 +1737,19 @@ internal static partial class RaylibApi {
     [UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
     internal static partial void DrawTextureNPatch(Texture2D texture, NPatchInfo nPatchInfo, Rectangle dest, Vector2 origin, float rotation, Color tint);
 
+    /// <summary>
+    /// Draw a textured polygon.
+    /// </summary>
+    /// <param name="texture">The texture to be drawn.</param>
+    /// <param name="center">Center position of the polygon.</param>
+    /// <param name="points">Polygon vertex coordinates.</param>
+    /// <param name="texcoords">Texture UV coordinates for each vertex.</param>
+    /// <param name="pointCount">Number of vertices in the polygon.</param>
+    /// <param name="tint">The color tint of the texture.</param>
+    [LibraryImport(Raylib.Name)]
+    [UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
+    internal static unsafe partial void DrawTexturePoly(Texture2D texture, Vector2 center, Vector2* points, Vector2* texcoords, int pointCount, Color tint);
+
     /* --------------------------------- Vr --------------------------------- */
 
     /// <summary>

--- a/src/Raylib-CSharp/Rendering/Graphics.cs
+++ b/src/Raylib-CSharp/Rendering/Graphics.cs
@@ -277,7 +277,7 @@ public static class Graphics {
     public static void DrawModelPoints(Model model, Vector3 position, float scale, Color tint) {
         RaylibApi.DrawModelPoints(model, position, scale, tint);
     }
-    
+
     /// <inheritdoc cref="RaylibApi.DrawModelPointsEx" />
     public static void DrawModelPointsEx(Model model, Vector3 position, Vector3 rotationAxis, float rotationAngle, Vector3 scale, Color tint) {
         RaylibApi.DrawModelPointsEx(model, position, rotationAxis, rotationAngle, scale, tint);
@@ -596,5 +596,14 @@ public static class Graphics {
     /// <inheritdoc cref="RaylibApi.DrawTextureNPatch" />
     public static void DrawTextureNPatch(Texture2D texture, NPatchInfo nPatchInfo, Rectangle dest, Vector2 origin, float rotation, Color tint) {
         RaylibApi.DrawTextureNPatch(texture, nPatchInfo, dest, origin, rotation, tint);
+    }
+
+    /// <inheritdoc cref="RaylibApi.DrawTexturePoly" />
+    public static unsafe void DrawTexturePoly(Texture2D texture, Vector2 center, Span<Vector2> points, Span<Vector2> texcoords, int pointCount, Color tint) {
+        fixed (Vector2* pointsPtr = points)
+        fixed (Vector2* texcoordsPtr = texcoords) {
+                RaylibApi.DrawTexturePoly(texture, center, pointsPtr, texcoordsPtr, pointCount, tint);
+
+        }
     }
 }


### PR DESCRIPTION
We have a project [O21](https://github.com/ForNeVeR/O21) and we are migrating the project from Raylib-CsLo to this binding. When migrating, I noticed that this library lacks a [function for drawing a textured polygon](https://jeroenjanssens.github.io/raylibr/reference/draw_texture_poly.html).